### PR TITLE
Get apikey from `Otoroshi-Authorization` header

### DIFF
--- a/otoroshi/app/env/Env.scala
+++ b/otoroshi/app/env/Env.scala
@@ -224,6 +224,7 @@ class Env(val configuration: Configuration,
     lazy val OtoroshiClientId             = configuration.getOptional[String]("otoroshi.headers.request.clientid").get
     lazy val OtoroshiClientSecret         = configuration.getOptional[String]("otoroshi.headers.request.clientsecret").get
     lazy val OtoroshiRequestId            = configuration.getOptional[String]("otoroshi.headers.request.id").get
+    lazy val OtoroshiAuthorization        = configuration.getOptional[String]("otoroshi.headers.request.authorization").get
     lazy val OtoroshiProxiedHost          = configuration.getOptional[String]("otoroshi.headers.response.proxyhost").get
     lazy val OtoroshiGatewayError         = configuration.getOptional[String]("otoroshi.headers.response.error").get
     lazy val OtoroshiErrorMsg             = configuration.getOptional[String]("otoroshi.headers.response.errormsg").get

--- a/otoroshi/app/gateway/handlers.scala
+++ b/otoroshi/app/gateway/handlers.scala
@@ -855,12 +855,14 @@ class GatewayRequestHandler(webSocketHandler: WebSocketHandler,
 
                     def passWithApiKey(config: GlobalConfig): Future[Result] = {
                       val authByJwtToken = req.headers
-                        .get("Authorization")
+                        .get(env.Headers.OtoroshiAuthorization)
+                        .orElse(req.headers.get("Authorization"))
                         .filter(_.startsWith("Bearer "))
                         .map(_.replace("Bearer ", ""))
                         .orElse(req.queryString.get("bearer_auth").flatMap(_.lastOption))
                       val authBasic = req.headers
-                        .get("Authorization")
+                        .get(env.Headers.OtoroshiAuthorization)
+                        .orElse(req.headers.get("Authorization"))
                         .filter(_.startsWith("Basic "))
                         .map(_.replace("Basic ", ""))
                         .flatMap(e => Try(decodeBase64(e)).toOption)

--- a/otoroshi/app/gateway/websockets.scala
+++ b/otoroshi/app/gateway/websockets.scala
@@ -404,12 +404,14 @@ class WebSocketHandler()(implicit env: Env) {
                       config: GlobalConfig
                   ): Future[Either[Result, Flow[PlayWSMessage, PlayWSMessage, _]]] = {
                     val authByJwtToken = req.headers
-                      .get("Authorization")
+                      .get(env.Headers.OtoroshiAuthorization)
+                      .orElse(req.headers.get("Authorization"))
                       .filter(_.startsWith("Bearer "))
                       .map(_.replace("Bearer ", ""))
                       .orElse(req.queryString.get("bearer_auth").flatMap(_.lastOption))
                     val authBasic = req.headers
-                      .get("Authorization")
+                      .get(env.Headers.OtoroshiAuthorization)
+                      .orElse(req.headers.get("Authorization"))
                       .filter(_.startsWith("Basic "))
                       .map(_.replace("Basic ", ""))
                       .flatMap(e => Try(decodeBase64(e)).toOption)

--- a/otoroshi/conf/application.conf
+++ b/otoroshi/conf/application.conf
@@ -322,6 +322,7 @@ otoroshi {
     request.clientid = "Otoroshi-Client-Id"
     request.clientsecret = "Otoroshi-Client-Secret"
     request.id = "Otoroshi-Request-Id"
+    request.authorization = "Otoroshi-Authorization"
     response.proxyhost = "Otoroshi-Proxied-Host"
     response.error = "Otoroshi-Error"
     response.errormsg = "Otoroshi-Error-Msg"


### PR DESCRIPTION
Using custom non-passing `Otoroshi-Authorization` header to send apikeys.

Linked to #65 