### PR TITLE
manual: java 9 and 10 startup from jar file

### DIFF
--- a/manual/src/main/paradox/firstrun/run.md
+++ b/manual/src/main/paradox/firstrun/run.md
@@ -12,8 +12,16 @@ cd otoroshi-vx.x.x
 
 ## From .jar file
 
+For Java 8
+
 ```sh
 java -jar otoroshi.jar
+```
+
+For Java 9 and 10
+
+```sh
+java --add-modules java.xml.bind -jar otoroshi.jar
 ```
 
 ## From docker

--- a/manual/src/main/paradox/index.md
+++ b/manual/src/main/paradox/index.md
@@ -23,7 +23,10 @@ You can install and run Otoroshi with this little bash snippet
 wget -q --show-progress 'https://dl.bintray.com/maif/binaries/otoroshi.jar/1.1.1/otoroshi.jar'
 # run the following line if you want to use the admin UI in your browser
 sudo echo "127.0.0.1    otoroshi-api.foo.bar otoroshi.foo.bar otoroshi-admin-internal-api.foo.bar" >> /etc/hosts
+# Java 8
 java -jar otoroshi.jar
+# Java 9 and 10
+java --add-modules java.xml.bind -jar otoroshi.jar
 ```
 
 or using docker

--- a/manual/src/main/paradox/quickstart.md
+++ b/manual/src/main/paradox/quickstart.md
@@ -34,8 +34,11 @@ wget -q --show-progress https://dl.bintray.com/maif/binaries/win-otoroshicli/1.1
 
 chmod +x otoroshicli
 
-# Run the Otoroshi server
+# Run the Otoroshi server on Java 8
 java -jar otoroshi.jar &
+
+# Run the Otoroshi server on Java 9 and 10
+java --add-modules java.xml.bind -jar otoroshi.jar &
 
 # Check if admin api works
 ./otoroshicli services all


### PR DESCRIPTION
Added `--add-modules java.xml.bind` option when launching with Java 9 or 10
fixes #109


