### PR TITLE
api key from jwt cookie named access_token

### DIFF
--- a/manual/src/main/paradox/usage/3-apikeys.md
+++ b/manual/src/main/paradox/usage/3-apikeys.md
@@ -24,6 +24,7 @@ In the Otoroshi admin dashboard, we chose to access `API keys` from `service des
 * `Authorization: Basic $base64(client_id:client_secret)` header, in that case, the `Authorization` header **will** be sent to the target
 * `Otoroshi-Authorization: Bearer $jwt_token` where the JWT token has been signed with the `API key` client secret, in that case, the `Otoroshi-Authorization` header will **not** be sent to the target
 * `Authorization: Bearer $jwt_token` where the JWT token has been signed with the `API key` client secret, in that case, the `Authorization` header **will** be sent to the target
+* `Cookie: access_token=$jwt_token;` where the JWT token has been signed with the `API key` client secret, in that case, the cookie named `access_token` **will** be sent to the target
 * `Otoroshi-Client-Id` and `Otoroshi-Client-Secret` headers, in that case the `Otoroshi-Client-Id` and `Otoroshi-Client-Secret` headers will not be sent to the target.
 
 ## List API keys for a service descriptor
@@ -102,7 +103,7 @@ and confirm the command
 ## Use a JWT token to pass an API key
 
 You can use a JWT token to pass an API key to Otoroshi. 
-You can use `Otoroshi-Authorization: Bearer $jwt_token` and `Authorization: Bearer $jwt_token` header to pass the JWT token.
+You can use `Otoroshi-Authorization: Bearer $jwt_token`, `Authorization: Bearer $jwt_token` header and `Cookie: access_token=$jwt_token;` to pass the JWT token.
 You have to create a JWT token with a signing algorythm that can be `HS256` or `HS512`. Then you have to provide an `iss` claim with the value of your API key `clientId` and sign the JWT token with your API key `clientSecret`.
 
 For example, with an API key like `clientId=abcdef` and `clientSecret=1234456789`, your JWT token should look like

--- a/otoroshi/app/gateway/handlers.scala
+++ b/otoroshi/app/gateway/handlers.scala
@@ -875,11 +875,7 @@ class GatewayRequestHandler(webSocketHandler: WebSocketHandler,
                         .filter(_.startsWith("Bearer "))
                         .map(_.replace("Bearer ", ""))
                         .orElse(req.queryString.get("bearer_auth").flatMap(_.lastOption))
-                        .orElse(req.headers.get("Cookie")
-                          .filter(_.startsWith("access_token="))
-                          .map(_.replace("access_token=", ""))
-                          .map(v => v.substring(0,v.indexOf(";")))
-                        )
+                        .orElse(req.cookies.get("access_token").map(_.value))
                       val authBasic = req.headers
                         .get(env.Headers.OtoroshiAuthorization)
                         .orElse(req.headers.get("Authorization"))

--- a/otoroshi/app/gateway/handlers.scala
+++ b/otoroshi/app/gateway/handlers.scala
@@ -875,6 +875,11 @@ class GatewayRequestHandler(webSocketHandler: WebSocketHandler,
                         .filter(_.startsWith("Bearer "))
                         .map(_.replace("Bearer ", ""))
                         .orElse(req.queryString.get("bearer_auth").flatMap(_.lastOption))
+                        .orElse(req.headers.get("Cookie")
+                          .filter(_.startsWith("access_token="))
+                          .map(_.replace("access_token=", ""))
+                          .map(v => v.substring(0,v.indexOf(";")))
+                        )
                       val authBasic = req.headers
                         .get(env.Headers.OtoroshiAuthorization)
                         .orElse(req.headers.get("Authorization"))

--- a/otoroshi/app/gateway/websockets.scala
+++ b/otoroshi/app/gateway/websockets.scala
@@ -437,6 +437,7 @@ class WebSocketHandler()(implicit env: Env) {
                       .filter(_.startsWith("Bearer "))
                       .map(_.replace("Bearer ", ""))
                       .orElse(req.queryString.get("bearer_auth").flatMap(_.lastOption))
+                      .orElse(req.cookies.get("access_token").map(_.value))
                     val authBasic = req.headers
                       .get(env.Headers.OtoroshiAuthorization)
                       .orElse(req.headers.get("Authorization"))

--- a/otoroshi/test/Suites.scala
+++ b/otoroshi/test/Suites.scala
@@ -80,7 +80,8 @@ object OtoroshiTests {
         new CircuitBreakerSpec(name, config),
         new CanarySpec(name, config),
         new QuotasSpec(name, config),
-        new AlertAndAnalyticsSpec(name, config)
+        new AlertAndAnalyticsSpec(name, config),
+        new ApiKeysSpec(name, config)
         // new WebsocketSpec(name, config)
       )
     }

--- a/otoroshi/test/functional/ApiKeysSpec.scala
+++ b/otoroshi/test/functional/ApiKeysSpec.scala
@@ -266,6 +266,24 @@ class ApiKeysSpec(name: String, configurationSpec: => Configuration)
       deleteOtoroshiService(service).futureValue
     }
 
+    "Allow access with access_token in cookie" in {
+      createOtoroshiService(service).futureValue
+
+      val resp = ws
+        .url(s"http://127.0.0.1:$port/api")
+        .withHttpHeaders(
+          "Host"          -> serviceHost,
+          "Cookie" -> s"access_token=$bearerAuth;secure"
+        )
+        .get()
+        .futureValue
+
+      resp.status mustBe 200
+      resp.body == basicTestExpectedBody mustBe true
+
+      deleteOtoroshiService(service).futureValue
+    }
+
     "Allow access with bearer otoroshi header (Otoroshi-Authorization)" in {
       createOtoroshiService(service).futureValue
 


### PR DESCRIPTION
API Key can now be provided by a cookie like so.

```
GET /
Host: test.com
Cookie: access_token=$jwt_token;secure
```

This would allow browser requests other than XHR to benefit from an API key.

fixes #124


