### PR TITLE
add logs for challenge

### DIFF
--- a/otoroshi/app/gateway/http.scala
+++ b/otoroshi/app/gateway/http.scala
@@ -528,7 +528,7 @@ class HttpHandler()(implicit env: Env) {
               if (
                 (descriptor.enforceSecureCommunication && descriptor.sendStateChallenge)
                 && !descriptor.isUriExcludedFromSecuredCommunication("/" + uri)
-                && !ReverseProxyActionHelper.stateRespValid(stateValue, stateResp, jti, descriptor)
+                && !ReverseProxyActionHelper.stateRespValid(stateValue, stateResp, jti, descriptor, logger)
               ) {
                 // && !headers.get(stateRespHeaderName).contains(state)) {
                 resp.ignore()


### PR DESCRIPTION
Hello,

I tried to implement V2 challenge as describe here : https://maif.github.io/otoroshi/manual/usage/2-services.html#v2-challenge

I have trouble making it work when I use an instance of Otoroshi deployed with **docker**. It's working perfectly when the instance is deployed with a simple jar. I tested it with version `1.4.22` and latest `1.5.0-alpha.9`.

I can't see what the problem as nothing is logged, I just know that Otoroshi doesn't validate the `Otoroshi-State-Resp` and so return an error to the caller.

This PR add simple logs to be able to debug those cases and help simplify the implementation of V2 challenge 😄 
