### PR TITLE
ZipFileBackend : populate cache with file after otoroshi restart

### DIFF
--- a/otoroshi/app/next/plugins/zip.scala
+++ b/otoroshi/app/next/plugins/zip.scala
@@ -113,6 +113,7 @@ class ZipFileBackend extends NgBackendCall {
               }
             }
           } else {
+            fileCache.put(filename, (System.currentTimeMillis(), Promise[String]()))
             fileCache.get(filename).foreach(_._2.trySuccess(filename))
             Right(new ZipFile(filename)).vfuture
           }


### PR DESCRIPTION
when otoroshi restart, the files from the zip backend are present on the filesystem but the cache is empty.

Previously, the file was served from the filesystem but the cache was never populated with it. Otoroshi always served the same version that never expired and never refreshed.


