### PR TITLE
add devcontainer to start working on otoroshi more easily

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../docker/dev/Dockerfile.devcontainer",
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"runArgs": [
+		"--add-host=host.docker.internal:host-gateway"
+	],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+		"type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly"
+	],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+
+	// Avoid the following error
+	//		root@f2825ecf3b49:/workspaces/test-mkdocs# git status
+	//		fatal: detected dubious ownership in repository at '/workspaces/test-mkdocs'
+	//		To add an exception for this directory, call:
+	//		
+	//				git config --global --add safe.directory /workspaces/test-mkdocs
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+}

--- a/docker/dev/Dockerfile.devcontainer
+++ b/docker/dev/Dockerfile.devcontainer
@@ -1,0 +1,41 @@
+FROM openjdk:11
+
+ENV HOME=/root
+
+WORKDIR $HOME
+
+RUN mkdir -p /root/otoroshi
+RUN mkdir -p /root/coder
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update -y
+RUN apt-get install -y git \
+    wget \
+    curl \
+    vim \
+    ack \
+    tig \
+    tree \
+    apt-transport-https \
+    openssl \
+    build-essential \
+    yarn
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.1/install.sh | bash
+RUN wget --quiet https://github.com/sbt/sbt/releases/download/v1.3.3/sbt-1.3.3.zip
+RUN unzip $HOME/sbt-1.3.3.zip
+RUN rm -f $HOME/sbt-1.3.3.zip
+RUN chmod -R 777 $HOME/.nvm
+
+RUN export NVM_DIR="/root/.nvm" && . "/root/.nvm/nvm.sh"
+RUN echo "export PATH=$PATH:/root/sbt/bin" >> .bashrc
+RUN echo "export NVM_DIR=\"/root/.nvm\"" >> .bashrc
+RUN echo ". \"/root/.nvm/nvm.sh\"" >> .bashrc
+
+RUN echo "Installing node"
+RUN export NVM_DIR="/root/.nvm" && \
+    . "/root/.nvm/nvm.sh" && \
+    nvm install 18 && \
+    nvm use 18 && \
+    nvm alias default 18


### PR DESCRIPTION
I tried to work on otoroshi previously, mainly to debug things but always had trouble installing the right versions of the tools and prevent conflict with tools I use for other projects. Most likely my fault as I break my work env every now and then 😆 

I started using [devcontainers](https://containers.dev/) for some project to make sure I have an environnement I can work on, break and start working again in minutes 🚀 

I added devcontainer tooling on Otoroshi to debug some thing and had success where I failed previously.
I used docker/dev/Dockerfile as a starting point but dropped some things (tmux, codeserver ...). 

Bonus gained : If I want to start working on Otoroshi, I just have to open vscode and start command "Dev containers: Reopen in container". I have a valid environnement to work on 🏆 

What do you think ? Might be useful for someone other than me ? 😄 