### PR TITLE
feat(helm): add redis doucmentation

### DIFF
--- a/kubernetes/helm/otoroshi/values.yaml
+++ b/kubernetes/helm/otoroshi/values.yaml
@@ -89,15 +89,57 @@ autoscaling:
       name: memory
       targetAverageUtilization: 80
 
-# redis
+# This block overrides values for the bitnami/redis chart dependency
+# For the full set of configurable options, see:
+# https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
+
 redis:
+  ## @param cluster.enabled Deploy Redis in cluster mode (master + slaves)
   cluster:
     enabled: false
-  usePassword: false
+  ## @param sentinel.enabled Enable Redis Sentinel support
   sentinel:
+    enabled: false
+    ## @param sentinel.usePassword Require password authentication on Sentinel instances
     usePassword: false
+  ## @param usePassword Enable Redis AUTH for master and slaves
+  usePassword: false
+  ## @param auth.enabled Enable password authentication for Redis® (newer chart versions)
   auth:
     enabled: false
+  master:
+    persistence:
+      ## @param master.persistence.enabled Enable persistence on Redis(R) master nodes using Persistent Volume Claims
+      enabled: true
+      ## @param master.persistence.storageClass Persistent Volume storage class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+      storageClass: ""
+      ## @param master.persistence.accessModes Persistent Volume access modes
+      accessModes:
+        - ReadWriteOnce
+      ## @param master.persistence.size Persistent Volume size
+      size: 8Gi
+      ## @param master.persistence.existingClaim Use an existing PVC which must be created manually before being bound
+      ## NOTE: Requires master.persistence.enabled: true
+      existingClaim: ""
+  replica:
+    persistence:
+      ## @param replica.persistence.enabled Enable persistence on Redis(R) replica nodes using Persistent Volume Claims
+      enabled: true
+      ## @param replica.persistence.storageClass Persistent Volume storage class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+      storageClass: ""
+      ## @param replica.persistence.accessModes Persistent Volume access modes
+      accessModes:
+        - ReadWriteOnce
+      ## @param replica.persistence.size Persistent Volume size
+      size: 8Gi
+      ## @param replica.persistence.existingClaim Use an existing PVC which must be created manually before being bound
+      ## NOTE: Requires replica.persistence.enabled: true
 
 webhooks:
   validation: true


### PR DESCRIPTION
### ✨ What’s Changed

This PR surfaces the default `bitnami/redis` chart values directly in Otoroshi’s `values.yaml` to make the Redis persistence configuration explicit and easier to find without navigating to the upstream repository:

* **Header comment** pointing to the upstream Redis values file
* **Master persistence** settings:

  * `enabled: true`
  * `storageClass: ""`
  * `accessModes: [ReadWriteOnce]`
  * `size: 8Gi`
  * `existingClaim: ""`
* **Replica persistence** settings (same as master)
* Redis **cluster mode**, **AUTH**, and **Sentinel AUTH** remain disabled by default

```diff
+# This block overrides values for the bitnami/redis chart dependency
+# For the full set of configurable options, see:
+# https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 redis:
   master:
     persistence:
       ## @param master.persistence.enabled Enable persistence on Redis(R) master nodes using Persistent Volume Claims
       enabled: true
       ## @param master.persistence.storageClass Persistent Volume storage class
       storageClass: ""
       ## @param master.persistence.accessModes Persistent Volume access modes
       accessModes:
         - ReadWriteOnce
       ## @param master.persistence.size Persistent Volume size
       size: 8Gi
       ## @param master.persistence.existingClaim Use an existing PVC which must be created manually before being bound
       existingClaim: ""

   replica:
     persistence:
       ## @param replica.persistence.enabled Enable persistence on Redis(R) replica nodes using Persistent Volume Claims
       enabled: true
       ## @param replica.persistence.storageClass Persistent Volume storage class
       storageClass: ""
       ## @param replica.persistence.accessModes Persistent Volume access modes
       accessModes:
         - ReadWriteOnce
       ## @param replica.persistence.size Persistent Volume size
       size: 8Gi
       ## @param replica.persistence.existingClaim Use an existing PVC which must be created manually before being bound
       existingClaim: ""
```
