### PR TITLE
In the route table, sort rows by name by default

### DIFF
--- a/otoroshi/javascript/src/pages/RouteDesigner/RoutesTable.js
+++ b/otoroshi/javascript/src/pages/RouteDesigner/RoutesTable.js
@@ -257,6 +257,7 @@ export function RoutesTable(props) {
   const fetchItems = (paginationState) =>
     nextClient.forEntityNext(nextClient.ENTITIES.ROUTES).findAllWithPagination({
       ...paginationState,
+      sorted: [{ id: "name", desc: true }],
       fields: [
         'backend.targets',
         'enabled',


### PR DESCRIPTION
Fix #2258 