### PR TITLE
Add Referrer-Policy and Permissions-Policy to Security Headers plugin

### DIFF
--- a/otoroshi/test/plugins/SecurityHeadersPluginTests.scala
+++ b/otoroshi/test/plugins/SecurityHeadersPluginTests.scala
@@ -29,7 +29,9 @@ class SecurityHeadersPluginTests(parent: PluginsTestSpec) {
               preload = true,
               onHttp = true
             ),
-            csp = CspConf(ENABLED, "default-src none; script-src self; connect-src self; img-src self; style-src self;")
+            csp = CspConf(ENABLED, "default-src none; script-src self; connect-src self; img-src self; style-src self;"),
+            referrerPolicy = ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            permissionsPolicy = PermissionsPolicyConf(true, "camera=(), microphone=(), geolocation=()")
           ).json.as[JsObject]
         )
       )
@@ -57,6 +59,8 @@ class SecurityHeadersPluginTests(parent: PluginsTestSpec) {
   headers(
     "Content-Security-Policy"
   ) mustBe "default-src none; script-src self; connect-src self; img-src self; style-src self;"
+  headers("Referrer-Policy") mustBe "strict-origin-when-cross-origin"
+  headers("Permissions-Policy") mustBe "camera=(), microphone=(), geolocation=()"
 
   deleteOtoroshiRoute(route).futureValue
 }


### PR DESCRIPTION
Fixes #2439

## Summary

  - Add `Referrer-Policy` header support with all standard directives (`no-referrer`, `no-referrer-when-downgrade`,
  `origin`, `origin-when-cross-origin`, `same-origin`, `strict-origin`, `strict-origin-when-cross-origin`, `unsafe-url`,
  `DISABLED`)
  - Add `Permissions-Policy` header support with an enabled toggle and free-text policy field
  - Both default to disabled for backward compatibility

  ## Changes

  - `otoroshi/app/next/plugins/security.scala`:
    - New `ReferrerPolicy` sealed trait + companion object (same pattern as `FrameOptions`)
    - New `PermissionsPolicyConf` case class with `Format` (same pattern as `HstsConf`)
    - Updated `SecurityHeadersPluginConfig`: new fields, config flow, config schema, serialization
    - Updated `transformResponse` to inject/remove the two new headers
  - `otoroshi/test/plugins/SecurityHeadersPluginTests.scala`:
    - Added `referrerPolicy` and `permissionsPolicy` to test config
    - Added assertions on `Referrer-Policy` and `Permissions-Policy` response headers

  ## Test plan

  - [x] `sbt compile` passes
  - [x] `sbt 'testOnly *PluginsTestSpec -- -t "Security Headers Plugin"'` passes
  - [x] Verify in the admin UI that the new fields appear in the plugin configuration form


