### PR TITLE
chore: use Mise for easier build/run

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,36 @@
+[tools]
+java = "openjdk-17.0.2"
+sbt = "1.7.2"
+node = "20"
+
+[tasks.dev]
+description = "Run otoroshi in dev mode with sbt"
+dir = "otoroshi"
+run = "sbt --java-home $JAVA_HOME run"
+
+[tasks.dev.env]
+OTOROSHI_INITIAL_ADMIN_LOGIN = "admin"
+OTOROSHI_INITIAL_ADMIN_PASSWORD = "password"
+OTOROSHI_API_CLIENT_ID = "admin"
+OTOROSHI_API_CLIENT_SECRET = "secret"
+
+[tasks.ui]
+description = "Start frontend dev server"
+dir = "otoroshi/javascript"
+run = "npm run webpack:start"
+
+[tasks.build]
+description = "Build otoroshi (compile, dist, assembly)"
+dir = "otoroshi"
+run = "sbt --java-home $JAVA_HOME compile dist assembly"
+
+[tasks.otoroshi]
+description = "Run otoroshi locally"
+dir = "otoroshi"
+run = "$JAVA_HOME/bin/java -jar target/scala-2.12/otoroshi.jar"
+
+[tasks.otoroshi.env]
+OTOROSHI_INITIAL_ADMIN_LOGIN = "admin"
+OTOROSHI_INITIAL_ADMIN_PASSWORD = "password"
+OTOROSHI_API_CLIENT_ID = "admin"
+OTOROSHI_API_CLIENT_SECRET = "secret"


### PR DESCRIPTION
[Mise](https://mise.jdx.dev/getting-started.html) is a meta package manager built in Rust, based on adsf ecosystem, with env/tasks as features to ease reproductible builds in a simple way, without new build system. 

This PR adds a `mise.toml` file at the root of the project. It doesn't impact users not using Mise, but allows its users to get and use the expected dependencies (Java/Node/SBT versions) automatically when they are in the project folder and easier Build/Run with dedicated local environment from Mise Tasks:

```
# Install Mise
curl https://mise.run | sh

# Activate it for Bash
echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc

# Or activate it for Zsh 
echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc

# Use Mise

mise install       # Get dependencies

mise run ui        # Launch Web UI Dev server
mise run dev       # Launch Otoroshi with sbt run
mise run build     # Build Otoroshi
mise run otoroshi  # Launch built Otoroshi
```

Feel free to adapt the file content. I made it to ease my own Otoroshi build. 