### PR TITLE
Accept $2b$ and $2y$ Bcrypt

### DIFF
--- a/otoroshi/app/auth/basic.scala
+++ b/otoroshi/app/auth/basic.scala
@@ -17,6 +17,7 @@ import org.joda.time.DateTime
 import org.mindrot.jbcrypt.BCrypt
 import otoroshi.auth.implicits.ResultWithPrivateAppSession
 import otoroshi.models.{OtoroshiAdminType, UserRight, UserRights, WebAuthnOtoroshiAdmin}
+import otoroshi.utils.crypto.BCryptHelper
 import otoroshi.utils.syntax.implicits._
 import play.api.Logger
 import play.api.libs.json._
@@ -260,7 +261,7 @@ case class BasicAuthModule(authConfig: BasicAuthModuleConfig) extends AuthModule
   ): Future[Either[ErrorReason, PrivateAppsUser]] = {
     authConfig.users
       .find(u => u.email == username)
-      .filter(u => BCrypt.checkpw(password, u.password)) match {
+      .filter(u => BCryptHelper.checkpw(password, u.password)) match {
       case Some(user) =>
         PrivateAppsUser(
           randomId = IdGenerator.token(64),
@@ -289,7 +290,7 @@ case class BasicAuthModule(authConfig: BasicAuthModuleConfig) extends AuthModule
   ): Future[Either[ErrorReason, BackOfficeUser]] = {
     authConfig.users
       .find(u => u.email == username)
-      .filter(u => BCrypt.checkpw(password, u.password)) match {
+      .filter(u => BCryptHelper.checkpw(password, u.password)) match {
       case Some(user) =>
         BackOfficeUser(
           randomId = IdGenerator.token(64),
@@ -436,7 +437,7 @@ case class BasicAuthModule(authConfig: BasicAuthModuleConfig) extends AuthModule
                 case true  =>
                   authConfig.users
                     .find(u => u.email == username)
-                    .filter(u => BCrypt.checkpw(password, u.password)) match {
+                    .filter(u => BCryptHelper.checkpw(password, u.password)) match {
                     case Some(user) =>
                       PrivateAppsUser(
                         randomId = IdGenerator.token(64),

--- a/otoroshi/app/controllers/PrivateAppsController.scala
+++ b/otoroshi/app/controllers/PrivateAppsController.scala
@@ -9,6 +9,7 @@ import otoroshi.env.Env
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 import org.mindrot.jbcrypt.BCrypt
+import otoroshi.utils.crypto.BCryptHelper
 import otoroshi.utils.mailer.EmailLocation
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -182,7 +183,7 @@ class PrivateAppsController(ApiAction: ApiAction, PrivateAppsAction: PrivateApps
       withShortSession(req) { case (bam, user, _) =>
         var newUser = user
         (req.body \ "password").asOpt[String] match {
-          case Some(pass) if BCrypt.checkpw(pass, user.password) => {
+          case Some(pass) if BCryptHelper.checkpw(pass, user.password) => {
             val name          = (req.body \ "name").asOpt[String].getOrElse(user.name)
             val newPassword   = (req.body \ "newPassword").asOpt[String]
             val reNewPassword = (req.body \ "reNewPassword").asOpt[String]

--- a/otoroshi/app/controllers/U2FController.scala
+++ b/otoroshi/app/controllers/U2FController.scala
@@ -24,6 +24,7 @@ import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import otoroshi.security.IdGenerator
+import otoroshi.utils.crypto.BCryptHelper
 import otoroshi.utils.syntax.implicits._
 
 import scala.concurrent.duration.Duration
@@ -66,7 +67,7 @@ class U2FController(
             case Some(user) => {
               val password = user.password
               val label    = user.label
-              if (BCrypt.checkpw(pass, password)) {
+              if (BCryptHelper.checkpw(pass, password)) {
                 if (logger.isDebugEnabled) logger.debug(s"Login successful for simple admin '$username'")
                 BackOfficeUser(
                   randomId = IdGenerator.token(64),
@@ -364,7 +365,7 @@ class U2FController(
                           Ok(Json.obj("username" -> username))
                         }
                     }
-                    case Some(user) if BCrypt.checkpw(password, user.password) => {
+                    case Some(user) if BCryptHelper.checkpw(password, user.password) => {
                       // update usrer
                       env.datastores.webAuthnAdminDataStore
                         .registerUser(
@@ -405,7 +406,7 @@ class U2FController(
         case (Some(username), Some(password)) => {
           env.datastores.webAuthnAdminDataStore.findAll().flatMap { users =>
             users.find(u => u.username == username) match {
-              case Some(user) if BCrypt.checkpw(password, user.password) => {
+              case Some(user) if BCryptHelper.checkpw(password, user.password) => {
 
                 val rpIdentity: RelyingPartyIdentity =
                   RelyingPartyIdentity.builder.id(reqOriginDomain).name("Otoroshi").build
@@ -475,7 +476,7 @@ class U2FController(
                     val password = user.password
                     val label    = user.label
 
-                    if (BCrypt.checkpw(pass, password)) {
+                    if (BCryptHelper.checkpw(pass, password)) {
                       Try {
                         val rpIdentity: RelyingPartyIdentity =
                           RelyingPartyIdentity.builder.id(reqOriginDomain).name("Otoroshi").build

--- a/otoroshi/app/next/plugins/auth.scala
+++ b/otoroshi/app/next/plugins/auth.scala
@@ -5,8 +5,8 @@ import akka.stream.Materializer
 import akka.util.ByteString
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import com.google.common.base.Charsets
-import org.mindrot.jbcrypt.BCrypt
 import otoroshi.auth.{AuthModuleConfig, BasicAuthModule, BasicAuthModuleConfig, LdapAuthModule, LdapAuthModuleConfig}
+import otoroshi.utils.crypto.BCryptHelper
 import otoroshi.auth.implicits.ResultWithPrivateAppSession
 import otoroshi.controllers.routes
 import otoroshi.env.Env
@@ -715,7 +715,7 @@ class SimpleBasicAuth extends NgAccessValidator {
 
   private def safeCheckPassword(password: String, hashed: String): Boolean = {
     try {
-      BCrypt.checkpw(password, hashed)
+      BCryptHelper.checkpw(password, hashed)
     } catch {
       case _: IllegalArgumentException => false
     }

--- a/otoroshi/app/utils/crypto.scala
+++ b/otoroshi/app/utils/crypto.scala
@@ -4,7 +4,24 @@ import java.nio.charset.StandardCharsets
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import org.mindrot.jbcrypt.BCrypt
 import otoroshi.utils.syntax.implicits._
+
+object BCryptHelper {
+
+  // jBCrypt 0.4.3 only accepts the $2a$ revision. $2a$, $2b$ and $2y$ are
+  // algorithmically identical, so rewriting the prefix lets us verify hashes
+  // produced by modern generators (Bun, OpenBSD, PHP password_hash, ...).
+  def checkpw(candidate: String, hashed: String): Boolean = {
+    if (hashed == null || hashed.isEmpty) false
+    else BCrypt.checkpw(candidate, normalize(hashed))
+  }
+
+  private def normalize(hashed: String): String = {
+    if (hashed.startsWith("$2b$") || hashed.startsWith("$2y$")) "$2a$" + hashed.substring(4)
+    else hashed
+  }
+}
 
 object Signatures {
 


### PR DESCRIPTION
This pull request refactors password verification logic throughout the codebase to use a new `BCryptHelper` utility. The main goal is to ensure compatibility with modern bcrypt hash formats (`$2b, `$2y) by normalizing them to the `$2a format required by the jBCrypt library. This improves interoperability with password hashes generated by various systems and libraries.

**Password verification compatibility improvements:**

* Introduced a new `BCryptHelper` object in `otoroshi/app/utils/crypto.scala` that normalizes bcrypt hashes with `$2b and `$2y prefixes to `$2a, ensuring compatibility with jBCrypt, and provides a `checkpw` method for password verification.
* Replaced all usages of `BCrypt.checkpw` with `BCryptHelper.checkpw` in authentication-related code, including `BasicAuthModule` (`otoroshi/app/auth/basic.scala`), `PrivateAppsController` (`otoroshi/app/controllers/PrivateAppsController.scala`), `U2FController` (`otoroshi/app/controllers/U2FController.scala`), and the simple basic auth plugin (`otoroshi/app/next/plugins/auth.scala`). [[1]](diffhunk://#diff-69b1c6b0e6b3f0fd67f85bfe61303f91bd8eb2208c429a04a259ac1277998259L263-R264) [[2]](diffhunk://#diff-69b1c6b0e6b3f0fd67f85bfe61303f91bd8eb2208c429a04a259ac1277998259L292-R293) [[3]](diffhunk://#diff-69b1c6b0e6b3f0fd67f85bfe61303f91bd8eb2208c429a04a259ac1277998259L439-R440) [[4]](diffhunk://#diff-d98880076620736e8c1cc11ce4054ba5a25f803589e76a8a4aacddb2f52cf1e9L185-R186) [[5]](diffhunk://#diff-14f47d9aad60bcd20ad6b672a84a3fd68f947f8ff66562d153e3f88289101635L69-R70) [[6]](diffhunk://#diff-14f47d9aad60bcd20ad6b672a84a3fd68f947f8ff66562d153e3f88289101635L367-R368) [[7]](diffhunk://#diff-14f47d9aad60bcd20ad6b672a84a3fd68f947f8ff66562d153e3f88289101635L408-R409) [[8]](diffhunk://#diff-14f47d9aad60bcd20ad6b672a84a3fd68f947f8ff66562d153e3f88289101635L478-R479) [[9]](diffhunk://#diff-3af6b9a1e3388da29a02584083992de0d8e302497090569e533544d7ec3274cbL718-R718)

**Code maintenance:**

* Updated import statements to use `BCryptHelper` instead of directly importing `org.mindrot.jbcrypt.BCrypt` in affected files. [[1]](diffhunk://#diff-69b1c6b0e6b3f0fd67f85bfe61303f91bd8eb2208c429a04a259ac1277998259R20) [[2]](diffhunk://#diff-d98880076620736e8c1cc11ce4054ba5a25f803589e76a8a4aacddb2f52cf1e9R12) [[3]](diffhunk://#diff-14f47d9aad60bcd20ad6b672a84a3fd68f947f8ff66562d153e3f88289101635R27) [[4]](diffhunk://#diff-3af6b9a1e3388da29a02584083992de0d8e302497090569e533544d7ec3274cbL8-R9)

Fixes #2548 