### PR TITLE
Increase sbt heap size to avoid heap space errors at compilation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,7 @@ run = [
 [tasks.dev-backend]
 description = "Run otoroshi backend in dev mode (sbt ~reStart, hot reload)"
 dir = "otoroshi"
-run = "sbt --java-home $JAVA_HOME ~reStart"
+run = "sbt -J-Xmx2G --java-home $JAVA_HOME ~reStart"
 
 [tasks.dev-backend.env]
 #OTOROSHI_INITIAL_ADMIN_LOGIN = "admin@otoroshi.io"


### PR DESCRIPTION
When starting otoroshi with `mise run dev`, I encountered following errors during compile:

```
[dev-backend] [warn] In the last 10 seconds, 5.381 (54.6%) were spent in GC. [Heap: 0.00GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
[dev-backend] [warn] In the last 10 seconds, 5.634 (57.2%) were spent in GC. [Heap: 0.02GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
[dev-backend] [error] Error while emitting otoroshi/plugins/jobs/kubernetes/OtoAnnotationConfig
[dev-backend] [error] Java heap space
```

Increasing sbt max heap space to 2G seems to fix this.


