### PR TITLE
Optional public domains and proper issuer for the helm certificate

### DIFF
--- a/kubernetes/helm/otoroshi/templates/cert.yaml
+++ b/kubernetes/helm/otoroshi/templates/cert.yaml
@@ -10,7 +10,7 @@ spec:
   description: "certificate for {{ .Values.service.name }}"
   autoRenew: true
   csr:
-    issuer: CN=Otoroshi Root
+    issuer: {{ .Values.certificate.issuer | quote }}
     hosts:
     {{- if .Values.cluster.enabled }}
     - {{ .Values.cluster.leaderApiServiceName }}
@@ -22,9 +22,18 @@ spec:
     - {{ .Values.service.name }}.{{ .Release.Namespace }}.svc.cluster.local
     - {{ .Values.service.apiName }}.{{ .Release.Namespace }}.svc.cluster.local
     {{- end }}
+    {{- if .Values.certificate.publicHosts.adminUi }}
     - otoroshi.{{ .Values.env.domain }}
+    {{- end }}
+    {{- if .Values.certificate.publicHosts.adminApi }}
     - otoroshi-api.{{ .Values.env.domain }}
+    {{- end }}
+    {{- if .Values.certificate.publicHosts.privateApps }}
     - privateapps.{{ .Values.env.domain }}
+    {{- end }}
+    {{- range .Values.certificate.extraHosts }}
+    - {{ . }}
+    {{- end }}
     key:
       algo: rsa
       size: 2048

--- a/kubernetes/helm/otoroshi/values.yaml
+++ b/kubernetes/helm/otoroshi/values.yaml
@@ -228,6 +228,27 @@ webhooks:
   # Injects an otoroshi-sidecar container into pods labeled `otoroshi.io/sidecar: inject`.
   sidecarInject: false
 
+# proxy.otoroshi.io/v1 Certificate generated for the Otoroshi services.
+# The in-cluster service names are always part of the certificate — cluster mode mTLS
+# between workers and the leader API relies on them.
+certificate:
+  # DN (or id) of the Otoroshi certificate signing the CSR. It must match an existing
+  # certificate, otherwise Otoroshi silently self-signs the generated one.
+  # The default is the intermediate CA Otoroshi generates on its first boot.
+  issuer: "CN=Otoroshi Default Intermediate CA Certificate, OU=Otoroshi Certificates, O=Otoroshi"
+  # Public hosts (built from env.domain) added to the certificate. Turn one off when another
+  # certificate already covers that domain: two certificates matching the same host make the
+  # one Otoroshi picks at TLS handshake time non-deterministic.
+  publicHosts:
+    # otoroshi.<env.domain>, the admin UI
+    adminUi: true
+    # otoroshi-api.<env.domain>, the admin API
+    adminApi: true
+    # privateapps.<env.domain>, the private apps authentication callbacks
+    privateApps: true
+  # Additional hosts appended verbatim to the certificate.
+  extraHosts: []
+
 # PodDisruptionBudget.
 pdb:
   enabled: false

--- a/manual/next/docs/deploy/kubernetes.mdx
+++ b/manual/next/docs/deploy/kubernetes.mdx
@@ -91,7 +91,16 @@ helm install my-otoroshi otoroshi/otoroshi --set gatewayApi.enabled=true
 helm install my-otoroshi otoroshi/otoroshi \
   --set 'loadbalancer.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-type=nlb' \
   --set 'loadbalancer.sourceRanges[0]=10.0.0.0/8'
+
+# Keep the public domains out of the certificate the chart generates
+# (another certificate already covers them)
+helm install my-otoroshi otoroshi/otoroshi \
+  --set certificate.publicHosts.adminUi=false \
+  --set certificate.publicHosts.adminApi=false \
+  --set certificate.publicHosts.privateApps=false
 ```
+
+The chart also creates a `proxy.otoroshi.io/v1` Certificate for the Otoroshi services, signed by the Otoroshi intermediate CA (`certificate.issuer`). It always covers the in-cluster service names, as cluster mode mTLS between the workers and the leader API relies on them, plus `otoroshi.<env.domain>`, `otoroshi-api.<env.domain>` and `privateapps.<env.domain>`. Turn those public ones off with `certificate.publicHosts.*` when you already have a certificate for these domains: when two certificates match the same host, the one Otoroshi presents at handshake time is not deterministic.
 
 :::warning
 Helm v3 only installs CRDs (under the chart's `crds/` directory) on the **first** `helm install`. When upgrading Otoroshi to a newer version, **re-apply the CRDs manually**:


### PR DESCRIPTION
fix #2628

The `Certificate` the helm chart generates had two problems.

**Issuer never matched anything.** `issuer: CN=Otoroshi Root` is resolved by the CRDs controller against the certificate ids and subject DNs (`customizeCert` -> `DN(...).isEqualsTo(...)`, `app/plugins/jobs/kubernetes/crds.scala`), and no certificate carries that DN: the new PKI creates `CN=Otoroshi Default Root CA Certificate, ...` and `CN=Otoroshi Default Intermediate CA Certificate, ...` (`app/jobs/certs.scala`). With no CA found, the controller silently falls back to `genSelfSignedCert`, so the service certificate was self-signed instead of being signed by the Otoroshi intermediate CA. It is now `certificate.issuer`, defaulting to the intermediate CA DN.

**The public domains were always there.** `otoroshi.<domain>`, `otoroshi-api.<domain>` and `privateapps.<domain>` are now behind `certificate.publicHosts.adminUi` / `.adminApi` / `.privateApps`, so they can be dropped when another certificate already covers them (two certificates matching the same host make the one presented at handshake time non-deterministic). `certificate.extraHosts` allows appending extra SANs.

The in-cluster service names stay unconditional, cluster mode mTLS between the workers and the leader API relies on them.

### Notes

- The three `publicHosts` default to `true`, so a `helm upgrade` renders the same hosts as before. Tell me if you would rather have them default to `false`.
- The issuer change does rotate that certificate on upgrade: `foundACertWithSameIdAndCsr` compares the stored csr and the `caRef`, so the controller regenerates it, signed by the intermediate CA this time. That is the point of the fix, but it is a visible change on existing installs.
- `kubernetes/kustomize/**` carries the same `issuer: CN=Otoroshi Root` in 4 deployment manifests. Left untouched here since the issue is about the helm chart, happy to do it in a follow-up.

### Test

```sh
helm lint kubernetes/helm/otoroshi
helm template oto kubernetes/helm/otoroshi -s templates/cert.yaml
helm template oto kubernetes/helm/otoroshi -s templates/cert.yaml --set cluster.enabled=true \
  --set certificate.publicHosts.adminUi=false --set certificate.publicHosts.adminApi=false \
  --set certificate.publicHosts.privateApps=false --set 'certificate.extraHosts={api.example.com}'
```

Default rendering is byte-identical to the previous one except the issuer line.
